### PR TITLE
Should remove old configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 ## Install
 
 - Install [Hammerspoon](https://www.hammerspoon.org/)
+- `rm -r ~/.hammerspoon`
 - `git clone https://github.com/wangshub/hammerspoon-config.git ~/.hammerspoon`
 
 ## License


### PR DESCRIPTION
Without removing old configuration one can not clone to the given directory after installing `Hammerspoon` as directory not empty

> fatal: destination path '~/.hammerspoon' already exists and is not an empty directory.